### PR TITLE
Ice multi zip 3.6.0

### DIFF
--- a/ice-multi-archive/create_ice_multi_zip.sh
+++ b/ice-multi-archive/create_ice_multi_zip.sh
@@ -24,7 +24,7 @@ pip_install_local()
     pushd ice-$1
     PYTHONUSERBASE=$PWD/usr pip install --user zeroc-ice==$1
     rm python
-    ln -s lib/python2.6/site-packages python
+    ln -s usr/lib/python2.6/site-packages python
     popd
 }
 

--- a/ice-multi-archive/create_ice_multi_zip.sh
+++ b/ice-multi-archive/create_ice_multi_zip.sh
@@ -19,6 +19,15 @@ extract_ice_rpms()
     popd
 }
 
+pip_install_local()
+{
+    pushd ice-$1
+    PYTHONUSERBASE=$PWD/usr pip install --user zeroc-ice==$1
+    rm python
+    ln -s lib/python2.6/site-packages python
+    popd
+}
+
 mkdir ice-rpms
 pushd ice-rpms
 
@@ -45,11 +54,8 @@ wget http://www.zeroc.com/download/Ice/3.5/Ice-3.5.1-el6-x86_64-rpm.tar.gz
 mkdir ice-3.5.1
 tar -C ice-3.5.1 -zxvf Ice-3.5.1-el6-x86_64-rpm.tar.gz
 
-# Zeroc ice-3.6 beta RPMS
-wget http://zeroc.com/download/Ice/3.6/Ice-3.6b-el6-x86_64-rpm.tar.gz
-mkdir ice-3.6b
-tar -C ice-3.6b -zxvf Ice-3.6b-el6-x86_64-rpm.tar.gz
-
+# Zeroc ice-3.6.0 RPMS
+wget -nd -P ice-3.6.0 -r -np -l1 -A rpm https://zeroc.com/download/rpm/el6/noarch https://zeroc.com/download/rpm/el6/x86_64
 popd
 
 mkdir ice
@@ -57,6 +63,11 @@ pushd ice
 
 for d in ../ice-rpms/ice-*/; do
     extract_ice_rpms $d
+done
+
+# ice-3.6.0 requires python to be installed using pip
+for v in 3.6.0; do
+    pip_install_local $v
 done
 
 cp ../ice-multi-config.sh ../test-ice-multi-config.sh .

--- a/ice-multi-archive/ice-multi-config.sh
+++ b/ice-multi-archive/ice-multi-config.sh
@@ -47,8 +47,8 @@ omero_env() {
             ICE_VERSION=3.5.1
             ;;
 
-        ice36b )
-            ICE_VERSION=3.6b
+        ice36 | ice360 )
+            ICE_VERSION=3.6.0
             ;;
 
         * )

--- a/ice-multi-archive/test-ice-multi-config.sh
+++ b/ice-multi-archive/test-ice-multi-config.sh
@@ -36,8 +36,9 @@ test_ice_version ice331 3.3.1
 test_ice_version ice342 3.4.2
 test_ice_version ice350 3.5.0
 test_ice_version ice351 3.5.1
+test_ice_version ice360 3.6.0
 
 test_ice_version ice33 3.3.1
 test_ice_version ice34 3.4.2
 test_ice_version ice35 3.5.1
-test_ice_version ice36b 3.6b
+test_ice_version ice36 3.6.0


### PR DESCRIPTION
Replace Ice 3.6b with 3.6.0. This also requires some hackery to pip install the 3.6.0 Python Ice module locally since it's not supplied as an RPM.
